### PR TITLE
Fix content legibility of system bars

### DIFF
--- a/app/src/main/res/values-v23/themes.xml
+++ b/app/src/main/res/values-v23/themes.xml
@@ -6,6 +6,11 @@
     </style>
 
     <style name="Theme.Splash" parent="Base.Theme.Splash">
+        <!--
+        statusBarColor can be transparent on API23 or higher, keeping content legibility in mind.
+        Because windowLightStatusBar is implemented from this API version.
+        -->
+        <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:windowLightStatusBar">true</item>
     </style>
 

--- a/app/src/main/res/values-v27/themes.xml
+++ b/app/src/main/res/values-v27/themes.xml
@@ -7,6 +7,12 @@
     </style>
 
     <style name="Theme.Splash" parent="Base.Theme.Splash">
+        <!--
+        navigationBarColor can be transparent on API27 or higher, keeping content legibility in mind.
+        Because windowLightNavigationBar is implemented from this API version.
+        -->
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:windowLightStatusBar">true</item>
         <item name="android:windowLightNavigationBar">true</item>
     </style>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -20,6 +20,14 @@
         <item name="windowSplashScreenBackground">@android:color/background_light</item>
         <item name="windowSplashScreenAnimatedIcon">@mipmap/ic_launcher_round</item>
         <item name="postSplashScreenTheme">@style/Theme.SplashSample</item>
+
+        <!--
+        statusBarColor/navigationBarColor should not be transparent on API22 & API21 for
+        content legibility, because windowLightStatusBar/windowLightNavigationBar are not
+        implemented on these API versions.
+        -->
+        <item name="android:statusBarColor">@android:color/black</item>
+        <item name="android:navigationBarColor">@android:color/black</item>
     </style>
 
     <style name="Theme.Splash" parent="Base.Theme.Splash" />


### PR DESCRIPTION
For the purpose of maintaining content legibility of system bars
on Theme.Splash, add color on statusBar/navigationBar on each
API version.

* API 21, 22
The statusBarColor/navigationBarColor is black.

* API 23, 24, 25, 26
The statusBarColor is transparent, and windowLightStatusBar=true.
The navigationBarColor is black.

* API 27, 28, 29, 30, 31
The statusBarColor is transparent, and windowLightStatusBar=true.
The navigationBarColor is transparent, and
windowLightNavigationBar=true


### Gif


||Before|After|
|:---:|:---:|:---:|
|API 22|![before_splash_api22](https://user-images.githubusercontent.com/18444125/136240784-cff7b1b1-96c2-4e3e-b172-7a296caa6dd3.gif)|![after_splash_api22](https://user-images.githubusercontent.com/18444125/136240858-5073d4d8-b452-4744-88e0-536de8f96a8a.gif)|
|API 25|![before_splash_api25](https://user-images.githubusercontent.com/18444125/136240970-f82b1527-d85a-4ac8-a175-9a38b2cddbd4.gif)|![after_splash_api25](https://user-images.githubusercontent.com/18444125/136241046-21bb33e4-0e03-4551-b38b-1e5eb2409665.gif)|
|API 28|![before_splash_api28](https://user-images.githubusercontent.com/18444125/136241129-27d8398f-6846-4d2f-abe4-a11b961ca1b2.gif)|![after_splash_api28](https://user-images.githubusercontent.com/18444125/136241195-a6161c79-79c6-4bf5-b14c-5a44bb41b801.gif)|